### PR TITLE
fixed undefined reference to `makedev'

### DIFF
--- a/cmux.c
+++ b/cmux.c
@@ -33,6 +33,7 @@
 #include <unistd.h>
 #include <err.h>
 #include <signal.h>
+#include <sys/sysmacros.h> //for makedev function
 /** 
 *	gsmmux.h provides n_gsm line dicipline structures and functions. 
 *	It should be kept in sync with your kernel release.


### PR DESCRIPTION
add #include <sys/sysmacros.h> library to cmux.c for using makedev function

otherwise the code give below error
```
make: Warning: File 'cmux.c' has modification time 9.8 s in the future
gcc -Wall    cmux.c   -o cmux
cmux.c: In function ‘make_nodes’:
cmux.c:232:12: warning: implicit declaration of function ‘makedev’; did you mean ‘make_nodes’? [-Wimplicit-function-declaration]
  232 |   device = makedev(major, minor);
      |            ^~~~~~~
      |            make_nodes
/usr/bin/ld: /tmp/cctCHk58.o: in function `make_nodes':
cmux.c:(.text+0x3bc): undefined reference to `makedev'
collect2: error: ld returned 1 exit status
make: *** [<builtin>: cmux] Error 1
````